### PR TITLE
fix: use concepts instead of std::function

### DIFF
--- a/src/utils/container.ixx
+++ b/src/utils/container.ixx
@@ -31,12 +31,15 @@ public:
 
     DELETE_COPY_AND_ASSIGN(RingBuffer);
 
-    bool push(T&& value, std::function<bool(const decltype(container_)&)> condition)
+    template<F>
+    requires std::invocable<F&, const decltype(container_)&> &&
+         std::same_as<std::invoke_result_t<F&, const decltype(container_)&>, bool>
+    bool push(T&& value, F&& condition)
     {
         DEBUG_LOG_SPAN(_);
         {
             auto lock = std::unique_lock<std::mutex>(mutex_);
-            if (!condition(container_))
+            if (!std::invoke(std::forward<F>(condition), container_))
             {
                 return false;
             }

--- a/src/utils/container.ixx
+++ b/src/utils/container.ixx
@@ -31,7 +31,7 @@ public:
 
     DELETE_COPY_AND_ASSIGN(RingBuffer);
 
-    template<F>
+    template<typename F>
     requires std::invocable<F&, const decltype(container_)&> &&
          std::same_as<std::invoke_result_t<F&, const decltype(container_)&>, bool>
     bool push(T&& value, F&& condition)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced the RingBuffer container's push method to support a wider variety of callable types, improving API flexibility and developer experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->