### PR TITLE
Make debug runtime self-contained

### DIFF
--- a/.zed/debug.json
+++ b/.zed/debug.json
@@ -2,8 +2,14 @@
   {
     "label": "Debug app",
     "build": {
-      "command": "nmake",
-      "args": ["build"],
+      "command": "pwsh.exe",
+      "args": [
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File",
+        "${ZED_WORKTREE_ROOT}/tools/build.ps1"
+      ],
       "cwd": "${ZED_WORKTREE_ROOT}"
     },
     "program": "${ZED_WORKTREE_ROOT}/build/Debug/simurator.exe",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,53 @@ find_package(boost_stacktrace_windbg CONFIG REQUIRED)
 find_package(Tesseract CONFIG REQUIRED)
 find_package(CUDAToolkit REQUIRED)
 
+function(copy_cuda_runtime_dlls target)
+    if(NOT WIN32)
+        return()
+    endif()
+
+    message(STATUS "${CUDAToolkit_BIN_DIR}")
+    file(GLOB_RECURSE CUDA_RUNTIME_DLLS
+        CONFIGURE_DEPENDS
+        "${CUDAToolkit_BIN_DIR}/*.dll"
+    )
+
+    if(CUDA_RUNTIME_DLLS)
+        add_custom_command(TARGET ${target} POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                ${CUDA_RUNTIME_DLLS}
+                $<TARGET_FILE_DIR:${target}>
+            COMMAND_EXPAND_LISTS
+            COMMENT "Copying CUDA runtime DLLs for ${target}"
+        )
+    endif()
+endfunction()
+
+function(copy_asan_runtime_dll target)
+    if(NOT MSVC)
+        return()
+    endif()
+
+    get_filename_component(CXX_COMPILER_DIR "${CMAKE_CXX_COMPILER}" DIRECTORY)
+    find_file(ASAN_RUNTIME_DLL
+        NAMES clang_rt.asan_dynamic-x86_64.dll
+        PATHS
+            "${CXX_COMPILER_DIR}"
+            "$ENV{VCToolsInstallDir}/bin/Hostx64/x64"
+            "$ENV{VCToolsInstallDir}/bin/Hostx86/x64"
+        NO_DEFAULT_PATH
+    )
+
+    if(ASAN_RUNTIME_DLL)
+        add_custom_command(TARGET ${target} POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                "${ASAN_RUNTIME_DLL}"
+                $<TARGET_FILE_DIR:${target}>
+            COMMENT "Copying AddressSanitizer runtime for ${target}"
+        )
+    endif()
+endfunction()
+
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_CXX_STANDARD 23) # c++latest or c++23(preview)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -110,6 +157,7 @@ target_compile_options(${PROJECT_NAME}-utils
 )
 target_compile_definitions(${PROJECT_NAME}-utils
     PRIVATE
+    SIMURATOR_TESSDATA_PREFIX="${CMAKE_CURRENT_SOURCE_DIR}/tessdata"
 )
 target_include_directories(${PROJECT_NAME}-utils
     PRIVATE
@@ -185,6 +233,8 @@ target_link_options(${PROJECT_NAME}
     /NODEFAULTLIB:LIBCMT
     $<$<CONFIG:RelWithDebInfo>:/DEBUG>
 )
+copy_cuda_runtime_dlls(${PROJECT_NAME})
+copy_asan_runtime_dll(${PROJECT_NAME})
 
 # tests
 enable_testing()
@@ -223,6 +273,8 @@ target_link_options(${PROJECT_NAME}-test
     /VERBOSE
     /NODEFAULTLIB:LIBCMT
 )
+copy_cuda_runtime_dlls(${PROJECT_NAME}-test)
+copy_asan_runtime_dll(${PROJECT_NAME}-test)
 
 add_test(NAME test COMMAND ${PROJECT_NAME}-test)
 

--- a/src/tests/test_env.cpp
+++ b/src/tests/test_env.cpp
@@ -1,0 +1,80 @@
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+
+import std;
+import utils;
+
+namespace
+{
+
+class ScopedEnv final
+{
+public:
+    ScopedEnv(const char* name, const char* value) : name_(name), original_(read_current(name))
+    {
+        set(value);
+    }
+
+    ~ScopedEnv()
+    {
+        if (original_)
+        {
+            set(original_->c_str());
+        }
+        else
+        {
+            set("");
+        }
+    }
+
+    ScopedEnv(const ScopedEnv&) = delete;
+    ScopedEnv& operator=(const ScopedEnv&) = delete;
+
+private:
+    static std::optional<std::string> read_current(const char* name)
+    {
+        char* value = nullptr;
+        size_t size = 0;
+        if (_dupenv_s(&value, &size, name) != 0 || value == nullptr)
+        {
+            return std::nullopt;
+        }
+
+        std::unique_ptr<char, decltype(&std::free)> owned(value, std::free);
+        if (size <= 1)
+        {
+            return std::string{};
+        }
+        return owned.get();
+    }
+
+    void set(const char* value)
+    {
+        EXPECT_EQ(_putenv_s(name_, value), 0);
+    }
+
+    const char* name_;
+    std::optional<std::string> original_;
+};
+
+TEST(test_env, get_env_returns_value)
+{
+    ScopedEnv env("SIMURATOR_TEST_ENV_VALUE", "simurator-test-value");
+
+    const auto value = sim::utils::get_env("SIMURATOR_TEST_ENV_VALUE");
+
+    ASSERT_TRUE(value);
+    EXPECT_EQ(*value, "simurator-test-value");
+}
+
+TEST(test_env, get_env_returns_nullopt_for_missing_value)
+{
+    ScopedEnv env("SIMURATOR_TEST_ENV_MISSING", "");
+
+    const auto value = sim::utils::get_env("SIMURATOR_TEST_ENV_MISSING");
+
+    EXPECT_FALSE(value);
+}
+
+}

--- a/src/utils/env.cpp
+++ b/src/utils/env.cpp
@@ -1,0 +1,29 @@
+module;
+
+#include <cstdlib>
+
+module utils;
+
+import :env;
+
+namespace sim::utils
+{
+
+std::optional<std::string> get_env(const char* name)
+{
+    std::size_t size = 0;
+    if (getenv_s(&size, nullptr, 0, name) != 0 || size == 0)
+    {
+        return std::nullopt;
+    }
+
+    std::string value(size, '\0');
+    if (getenv_s(&size, value.data(), value.size(), name) != 0 || size == 0)
+    {
+        return std::nullopt;
+    }
+    value.resize(size - 1); // remove trailing NUL
+    return value;
+}
+
+}

--- a/src/utils/env.ixx
+++ b/src/utils/env.ixx
@@ -1,0 +1,10 @@
+module;
+
+export module utils:env;
+
+import std;
+
+namespace sim::utils
+{
+export std::optional<std::string> get_env(const char* name);
+}

--- a/src/utils/recognize.cpp
+++ b/src/utils/recognize.cpp
@@ -11,9 +11,14 @@ module;
 module utils;
 
 import std;
+import :env;
 import :logger;
 import :recognize;
 import :file;
+
+#ifndef SIMURATOR_TESSDATA_PREFIX
+#define SIMURATOR_TESSDATA_PREFIX ""
+#endif
 
 namespace
 {
@@ -28,6 +33,22 @@ auto LoadFontData()
         freetype->loadFontData("C:/Windows/Fonts/meiryo.ttc", 0);
     }
     return freetype;
+}
+
+std::string TessDataPrefix()
+{
+    if (const auto env = sim::utils::get_env("TESSDATA_PREFIX"))
+    {
+        return *env;
+    }
+
+    constexpr const char* prefix = SIMURATOR_TESSDATA_PREFIX;
+    if (prefix[0] != '\0')
+    {
+        return prefix;
+    }
+
+    return {};
 }
 
 }
@@ -123,7 +144,8 @@ public:
         DEBUG_LOG_SPAN(_);
         // returns 0:success
 //        const auto result = tess_.Init(nullptr, "jpn", tesseract::OEM_LSTM_ONLY);
-        const auto result = tess_.Init(nullptr, "jpn");
+        const auto tessdata_prefix = TessDataPrefix();
+        const auto result = tess_.Init(tessdata_prefix.empty() ? nullptr : tessdata_prefix.c_str(), "jpn");
         if (result != 0) {
             logging::log("Failed to init tesseract.");
             DEBUG_ASSERT(false);

--- a/src/utils/utils.ixx
+++ b/src/utils/utils.ixx
@@ -3,6 +3,7 @@ export module utils;
 export import :algorithm;
 export import :capture;
 export import :container;
+export import :env;
 export import :error;
 export import :file;
 export import :gpu;


### PR DESCRIPTION
Summary
- Build Zed debug targets through tools/build.ps1 so env setup runs before building.
- Copy CUDA and AddressSanitizer runtime DLLs next to built executables.
- Add a utils get_env helper and use a built-in tessdata fallback when TESSDATA_PREFIX is unset.
- Add tests for get_env.

Validation
- nmake test: 25 tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tesseract now supports configuration via environment variables with compile-time fallback defaults
  * Introduced new utility for retrieving environment variable values

* **Chores**
  * Updated debug build configuration to use PowerShell scripting
  * Enhanced build system to automatically handle CUDA and ASAN runtime dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->