### PR TITLE
Use debug assert for ring buffer capacity

### DIFF
--- a/src/utils/container.ixx
+++ b/src/utils/container.ixx
@@ -1,10 +1,9 @@
 module;
 
-#include <cassert>
-
 #include <boost/circular_buffer.hpp>
 
 #include "macro.hpp"
+#include "debug.hpp"
 #include "logger.hpp"
 
 export module utils:container;
@@ -25,7 +24,7 @@ private:
 public:
     explicit RingBuffer(std::size_t capacity) noexcept : container_(capacity), mutex_()
     {
-        assert(capacity > 0);
+        DEBUG_ASSERT(capacity > 0);
     }
     ~RingBuffer() = default;
 


### PR DESCRIPTION
Summary
- Replace the RingBuffer capacity check's standard assert with DEBUG_ASSERT.
- Remove the now-unused <cassert> include and include debug.hpp instead.

Validation
- nmake test: 25 tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal assertion handling in debug builds to enhance code quality and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->